### PR TITLE
Add ARM64 S-EL2 SPMC hypervisor to CC Software Stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Source: [Understanding a confidential computing solution](https://bit.ly/cc-solu
 * [Occlum Library OS](https://github.com/occlum/occlum)
 * [Openenclave SDK](https://github.com/openenclave/openenclave)
 * [Veracruz](https://github.com/veracruz-project/veracruz)
+* [Hypervisor (ARM64 S-EL2 SPMC)](https://github.com/willamhou/hypervisor) - ARM64 Type-1 bare-metal hypervisor and S-EL2 SPMC in no_std Rust. Implements FF-A v1.1 memory sharing with Stage-2 PTE page ownership tracking (pKVM-compatible), manages Secure Partitions at S-EL1, and coexists with pKVM at NS-EL2
 
 
 ## Attestation


### PR DESCRIPTION
## Summary

Adds [willamhou/hypervisor](https://github.com/willamhou/hypervisor) to the **CC Software Stack (Active and Open source)** section.

This is an open-source ARM64 Type-1 bare-metal hypervisor and **S-EL2 SPMC** (Secure Partition Manager Core) written in `no_std` Rust. It is relevant to ARM CCA / TrustZone confidential computing:

- **FF-A v1.1 memory isolation**: Implements MEM_SHARE/LEND/DONATE/RETRIEVE/RELINQUISH/RECLAIM with Stage-2 PTE software bits for page ownership tracking (Owned, SharedOwned, SharedBorrowed, Donated), matching the pKVM page ownership model
- **S-EL2 SPMC role**: Runs at Secure EL2 as BL32 in the TF-A boot chain, managing Secure Partitions at S-EL1 with per-SP Secure Stage-2 isolation
- **pKVM coexistence**: Designed to coexist with pKVM at NS-EL2 — validated with AOSP android16-6.12 kernel (`kvm-arm.mode=protected`), 35/35 FF-A integration tests passing
- **Full FF-A v1.1 proxy**: VERSION, ID_GET, FEATURES, RXTX, PARTITION_INFO_GET, DIRECT_REQ/RESP, memory sharing, notifications, indirect messaging, fragmentation, CONSOLE_LOG
- **~457 assertions across 34 test suites**, 20/20 BL33 E2E integration tests

The project demonstrates a complete, tested implementation of the ARM confidential computing firmware stack (SPMC) that can serve as a reference or foundation for ARM CCA research and development.