### PR TITLE
Add Confidential AI to the Confidential AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Source: [Understanding a confidential computing solution](https://bit.ly/cc-solu
 * [Red Hat: AI Inference with Confidential Computing](https://next.redhat.com/2025/10/23/enhancing-ai-inference-security-with-confidential-computing-a-path-to-private-data-inference-with-proprietary-llms/)
 * [Red Hat: Confidential Containers with NVIDIA Accelerated Computing](https://www.redhat.com/en/blog/ai-meets-security-poc-run-workloads-confidential-containers-using-nvidia-accelerated-computing)
 * [dstack](https://github.com/Dstack-TEE/dstack)
+* [Confidential AI - End-to-end private OpenClaw agents with confidential inference in AMD SEV-SNP TEEs](https://confidential.ai)
 
 
 ## Security Threats and Vulnerabilities


### PR DESCRIPTION
Adds Confidential AI (https://confidential.ai) to the **Confidential AI** section.

Confidential AI's Confidential Agents API runs end-to-end private OpenClaw agents with confidential inference inside hardware-attested AMD SEV-SNP Trusted Execution Environments, so the operator cannot see user data or prompts.

Single entry, placed alongside the existing Confidential AI offerings (Tinfoil, Private Mode AI, dstack):

```
* [Confidential AI - End-to-end private OpenClaw agents with confidential inference in AMD SEV-SNP TEEs](https://confidential.ai)
```
